### PR TITLE
Fixed Null-Terminate

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -41,16 +41,18 @@ void spawn_program(const char *command) {
 
             // Make a copy of the command arguments
             size_t size_of_command = strlen(command);
-            char *command_copy = malloc(size_of_command + 9);
+            char *command_copy = malloc(size_of_command + 1); // +1 for null terminator
             memcpy(command_copy, command, size_of_command);
+            command_copy[size_of_command] = '\0'; // Add null-terminator
+
 
             // Tokenize the command to pass to execvp
 
-            strcat(command_copy, " replace");
             char **args = NULL;
             int count = strsplit(command_copy, ' ', &args);
 
-            args[count - 1] = NULL; // the last argument is replace which we are nulling out for execve
+            args = realloc(args, (count + 1) * sizeof(char*));
+            args[count] = NULL; // Set the last element to NULL
 
             if (execvp(args[0], args) == -1) { // If execvp fails, it returns -1
                 perror("Failed to launch program");


### PR DESCRIPTION
In the original code, the `command_copy` variable is not properly null-terminated after being copied from the `command` argument. To fix this issue, add a null terminator at the end of the copied characters. Here's the change:
```c
// Before:
size_t size_of_command = strlen(command);
char *command_copy = malloc(size_of_command + 9);
memcpy(command_copy, command, size_of_command);

// After:
size_t size_of_command = strlen(command);
char *command_copy = malloc(size_of_command + 1); // +1 for null terminator
memcpy(command_copy, command, size_of_command);
command_copy[size_of_command] = '\0'; // Add null-terminator
```
In the original code, the `args` array is created based on the number of tokens obtained from `strsplit`. However, since `execvp` expects the array to be terminated with a NULL pointer, you need to allocate one extra element for the NULL terminator. Here's the change:
```c
// Before:
int count = strsplit(command_copy, ' ', &args);

// After:
int count = strsplit(command_copy, ' ', &args);
args = realloc(args, (count + 1) * sizeof(char*));
args[count] = NULL; // Set the last element to NULL
```

This should change the issues within #8 